### PR TITLE
Fixes fib import zmq_rpcclient

### DIFF
--- a/examples/zmq_rpcclient.py
+++ b/examples/zmq_rpcclient.py
@@ -3,7 +3,7 @@
 import curio_zmq as zmq
 from curio import sleep, spawn
 
-from hello import fib
+from fibserve import fib
 
 async def ticker():
     n = 0


### PR DESCRIPTION
no hello module. fib lives in fibserve.